### PR TITLE
CI testing

### DIFF
--- a/.github/workflows/bare_run.yaml
+++ b/.github/workflows/bare_run.yaml
@@ -1,6 +1,10 @@
 name: Bare Run
 
-on: [pull_request, push]
+on:
+    pull_request: null
+    push:
+        branches:
+            - main
 
 jobs:
     bare_run:

--- a/.github/workflows/finalize_classes.yaml
+++ b/.github/workflows/finalize_classes.yaml
@@ -1,6 +1,10 @@
 name: Rector Run
 
-on: [pull_request, push]
+on:
+    pull_request: null
+    push:
+        branches:
+            - main
 
 jobs:
     rector_run:

--- a/.github/workflows/php8_attributes.yaml
+++ b/.github/workflows/php8_attributes.yaml
@@ -14,16 +14,4 @@ jobs:
                     php-version: '8.0'
                     coverage: none
 
-            -   run: |
-                    mkdir standalone
-                    cd standalone
-                    # wait for deploy to packagist
-                    sleep 70
-
-            -   run: |
-                    cd standalone
-                    # run
-                    composer require rector/rector-prefixed:dev-main --dev --ansi
-
-            -
-                run: vendor/bin/rector process ../tests/fixture-php8-attributes --config ../ci/rector-attributes.php --ansi
+            -   run: bin/rector process tests/fixture-php8-attributes --config ci/rector-attributes.php --ansi

--- a/.github/workflows/php8_attributes.yaml
+++ b/.github/workflows/php8_attributes.yaml
@@ -1,0 +1,29 @@
+name: PHP 8 Attributes
+
+on: [pull_request, push]
+
+jobs:
+    php8_attributes:
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: '8.0'
+                    coverage: none
+
+            -   run: |
+                    mkdir standalone
+                    cd standalone
+                    # wait for deploy to packagist
+                    sleep 70
+
+            -   run: |
+                    cd standalone
+                    # run
+                    composer require rector/rector-prefixed:dev-main --dev --ansi
+
+            -
+                run: vendor/bin/rector process ../tests/fixture-php8-attributes --config ../ci/rector-attributes.php --ansi

--- a/.github/workflows/php8_attributes.yaml
+++ b/.github/workflows/php8_attributes.yaml
@@ -1,6 +1,10 @@
 name: PHP 8 Attributes
 
-on: [pull_request, push]
+on:
+    pull_request: null
+    push:
+        branches:
+            - main
 
 jobs:
     php8_attributes:

--- a/ci/rector-attributes.php
+++ b/ci/rector-attributes.php
@@ -7,6 +7,9 @@ use Rector\Core\ValueObject\PhpVersion;
 use Rector\Symfony\Set\SymfonySetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+// route class must exist and be loaded, as annotation parser uses dynamic reflection
+require_once __DIR__ . '/../stubs/Symfony/Component/Routing/Annotation/Route.php';
+
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SymfonySetList::SYMFONY_52);
 

--- a/ci/rector-attributes.php
+++ b/ci/rector-attributes.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
+use Rector\Core\Configuration\Option;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\Symfony\Set\SymfonySetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(SymfonySetList::SYMFONY_52);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PHP_VERSION_FEATURES, PhpVersion::PHP_80);
 };

--- a/ci/rector-attributes.php
+++ b/ci/rector-attributes.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Symfony\Set\SymfonySetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(SymfonySetList::SYMFONY_52);
+};

--- a/stubs/Symfony/Component/Routing/Annotation/Route.php
+++ b/stubs/Symfony/Component/Routing/Annotation/Route.php
@@ -1,0 +1,177 @@
+<?php
+
+/** @source https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Annotation/Route.php */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Routing\Annotation;
+
+if (class_exists('Symfony\Component\Routing\Annotation\Route')) {
+    return;
+}
+
+/**
+ * @Annotation
+ * @Target({"CLASS", "METHOD"})
+ */
+class Route
+{
+    private $path;
+    private $localizedPaths = [];
+    private $name;
+    private $requirements = [];
+    private $options = [];
+    private $defaults = [];
+    private $host;
+    private $methods = [];
+    private $schemes = [];
+    private $condition;
+    private $locale;
+    private $format;
+    private $utf8;
+
+    /**
+     * @param array $data An array of key/value parameters
+     *
+     * @throws \BadMethodCallException
+     */
+    public function __construct(array $data)
+    {
+        if (isset($data['localized_paths'])) {
+            throw new \BadMethodCallException(sprintf('Unknown property "localized_paths" on annotation "%s".', \get_class($this)));
+        }
+
+        if (isset($data['value'])) {
+            $data[\is_array($data['value']) ? 'localized_paths' : 'path'] = $data['value'];
+            unset($data['value']);
+        }
+
+        if (isset($data['path']) && \is_array($data['path'])) {
+            $data['localized_paths'] = $data['path'];
+            unset($data['path']);
+        }
+
+        if (isset($data['locale'])) {
+            $data['defaults']['_locale'] = $data['locale'];
+            unset($data['locale']);
+        }
+
+        if (isset($data['format'])) {
+            $data['defaults']['_format'] = $data['format'];
+            unset($data['format']);
+        }
+
+        if (isset($data['utf8'])) {
+            $data['options']['utf8'] = filter_var($data['utf8'], FILTER_VALIDATE_BOOLEAN) ?: false;
+            unset($data['utf8']);
+        }
+
+        foreach ($data as $key => $value) {
+            $method = 'set'.str_replace('_', '', $key);
+            if (!method_exists($this, $method)) {
+                throw new \BadMethodCallException(sprintf('Unknown property "%s" on annotation "%s".', $key, \get_class($this)));
+            }
+            $this->$method($value);
+        }
+    }
+
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function setLocalizedPaths(array $localizedPaths)
+    {
+        $this->localizedPaths = $localizedPaths;
+    }
+
+    public function getLocalizedPaths(): array
+    {
+        return $this->localizedPaths;
+    }
+
+    public function setHost($pattern)
+    {
+        $this->host = $pattern;
+    }
+
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setRequirements($requirements)
+    {
+        $this->requirements = $requirements;
+    }
+
+    public function getRequirements()
+    {
+        return $this->requirements;
+    }
+
+    public function setOptions($options)
+    {
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function setDefaults($defaults)
+    {
+        $this->defaults = $defaults;
+    }
+
+    public function getDefaults()
+    {
+        return $this->defaults;
+    }
+
+    public function setSchemes($schemes)
+    {
+        $this->schemes = \is_array($schemes) ? $schemes : [$schemes];
+    }
+
+    public function getSchemes()
+    {
+        return $this->schemes;
+    }
+
+    public function setMethods($methods)
+    {
+        $this->methods = \is_array($methods) ? $methods : [$methods];
+    }
+
+    public function getMethods()
+    {
+        return $this->methods;
+    }
+
+    public function setCondition($condition)
+    {
+        $this->condition = $condition;
+    }
+
+    public function getCondition()
+    {
+        return $this->condition;
+    }
+}

--- a/tests/fixture-php8-attributes/route.php
+++ b/tests/fixture-php8-attributes/route.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class SomeController
+{
+    /**
+     * @Route()
+     */
+    public function someMethod()
+    {
+    }
+}


### PR DESCRIPTION
Since rector configs are now in vendor, they should be unprefixed too.

Might be fixed with https://github.com/rectorphp/rector/commit/231c447bcb659eba18c656a6011b7b9394a6c6f6